### PR TITLE
Don't focus Output pane on errors because request handler errors are common and recoverable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v0.2.6: 3 Nov 2017
+  - Don't focus Output pane on errors because request handler errors are common and recoverable
+
 ### v0.2.5: 3 Nov 2017
   - Improve error output in debugger and fix failures to launch debugger
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Jake Becker",
   "license": "MIT",
   "publisher": "JakeBecker",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "engines": {
     "vscode": "^1.8.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import { workspace, Disposable, ExtensionContext } from "vscode";
 import {
   LanguageClient,
   LanguageClientOptions,
+  RevealOutputChannelOn,
   SettingMonitor,
   ServerOptions,
   TransportKind
@@ -39,6 +40,8 @@ export function activate(context: ExtensionContext) {
   let clientOptions: LanguageClientOptions = {
     // Register the server for Elixir documents
     documentSelector: ["elixir"],
+    // Don't focus the Output pane on errors because request handler errors are no big deal
+    revealOutputChannelOn: RevealOutputChannelOn.Never,
     synchronize: {
       // Synchronize the setting section 'elixirLS' to the server
       configurationSection: "elixirLS",


### PR DESCRIPTION
Fixes #19 