### PR TITLE
Indent lines after trailing =

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 
 export const configuration: vscode.LanguageConfiguration = {
   indentationRules: {
-    increaseIndentPattern: new RegExp('(after|else|catch|rescue|fn|^.*(do|<\\-|\\->|\\{|\\[))\\s*$'),
+    increaseIndentPattern: new RegExp('(after|else|catch|rescue|fn|^.*(do|<\\-|\\->|\\{|\\[|\\=))\\s*$'),
     decreaseIndentPattern: new RegExp('^\\s*((\\}|\\])\\s*$|(after|else|catch|rescue|end)\\b)')
   }
 };


### PR DESCRIPTION
Hi there 👋

This PR adds an indentation rule to increase the indentation after a line with a trailing `=`.

This is useful for assignments followed by multiple pipes:

```elixir
my_var =
  42
  |> foo()
  |> bar()
  |> baz()
```

Best 🤗 