### PR TITLE
Change "Eex" to official name "EEx"

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,9 +104,9 @@
         "configuration": "./elixir.configuration.json"
       },
       {
-        "id": "Eex",
+        "id": "EEx",
         "aliases": [
-          "Eex",
+          "EEx",
           "eex"
         ],
         "extensions": [
@@ -114,9 +114,9 @@
         ]
       },
       {
-        "id": "HTML (Eex)",
+        "id": "HTML (EEx)",
         "aliases": [
-          "HTML (Eex)"
+          "HTML (EEx)"
         ],
         "extensions": [
           ".html.eex"
@@ -130,12 +130,12 @@
         "path": "./syntaxes/elixir.json"
       },
       {
-        "language": "Eex",
+        "language": "EEx",
         "scopeName": "text.elixir",
         "path": "./syntaxes/eex.json"
       },
       {
-        "language": "HTML (Eex)",
+        "language": "HTML (EEx)",
         "scopeName": "text.html.elixir",
         "path": "./syntaxes/html (eex).json"
       }


### PR DESCRIPTION
[EEx](https://hexdocs.pm/eex/EEx.html) stands for Embedded Elixir. Currently, the (incorrect) language name "Eex" and "HTML (Eex)" are shown in the language list.