### PR TITLE
Support EEx tags inside HTML attributes

### DIFF
--- a/syntaxes/html (eex).json
+++ b/syntaxes/html (eex).json
@@ -4,6 +4,16 @@
   ],
   "foldingStartMarker": "(?x)\n\t\t(<(?i:head|body|table|thead|tbody|tfoot|tr|div|select|fieldset|style|script|ul|ol|form|dl)\\b.*?>\n\t\t|<!--(?!.*-->)\n\t\t|\\{\\s*($|\\?>\\s*$|//|/\\*(.*\\*/\\s*$|(?!.*?\\*/)))\n\t\t)",
   "foldingStopMarker": "(?x)\n\t\t(</(?i:head|body|table|thead|tbody|tfoot|tr|div|select|fieldset|style|script|ul|ol|form|dl)>\n\t\t|^\\s*-->\n\t\t|(^|\\s)\\}\n\t\t)",
+  "injections": {
+    "R:text.html.elixir meta.tag meta.attribute string.quoted": {
+      "comment": "Uses R: to ensure this matches after any other injections.",
+      "patterns": [
+        {
+          "include": "text.elixir"
+        }
+      ]
+    }
+  },
   "name": "HTML (EEx)",
   "patterns": [
     {


### PR DESCRIPTION
Fix EEx highlighting when embedded inside HTML attributes.

**Before**
![1](https://user-images.githubusercontent.com/4433966/50814206-d21f7100-1353-11e9-8726-c5d692d24e1e.png)

**After**
![2](https://user-images.githubusercontent.com/4433966/50815871-ab643900-1359-11e9-9718-ca3474441b55.png)

Function calls are still coloured green from inheriting `string.quoted.double.html` because `source.elixir.embedded` isn’t themed.

Code adapted from elixir-editors/elixir-tmbundle#100’s fix (credits to @infininight).