### PR TITLE
Adds syntax rules for LiveView and Eex sigil heredocs

### DIFF
--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -1421,6 +1421,222 @@
       "name": "string.quoted.double.literal.elixir"
     },
     {
+      "comment": "String Eex heredoc with double quotes",
+      "begin": "\\s?(~E\"\"\")$",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        },
+        "1": {
+          "name": "string.quoted.double.heredoc.elixir"
+        }
+      },
+      "end": "^\\s*(\"\"\"[a-z]*)$",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        },
+        "1": {
+          "name": "string.quoted.double.heredoc.elixir"
+        }
+      },
+      "name": "text.html.elixir",
+      "patterns": [
+        {
+          "include": "text.html.elixir"
+        }
+      ]
+    },
+    {
+      "comment": "String Eex heredoc with double quotes",
+      "begin": "\\s?(~e\"\"\")$",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        },
+        "1": {
+          "name": "string.quoted.double.heredoc.elixir"
+        }
+      },
+      "end": "^\\s*(\"\"\"[a-z]*)$",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        },
+        "1": {
+          "name": "string.quoted.double.heredoc.elixir"
+        }
+      },
+      "name": "text.html.elixir",
+      "patterns": [
+        {
+          "include": "text.html.elixir"
+        }
+      ]
+    },
+    {
+      "comment": "String Eex heredoc with single quotes",
+      "begin": "\\s?(~E''')$",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        },
+        "1": {
+          "name": "string.quoted.double.heredoc.elixir"
+        }
+      },
+      "end": "^\\s*('''[a-z]*)$",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        },
+        "1": {
+          "name": "string.quoted.double.heredoc.elixir"
+        }
+      },
+      "name": "text.html.elixir",
+      "patterns": [
+        {
+          "include": "text.html.elixir"
+        }
+      ]
+    },
+    {
+      "comment": "String Eex heredoc with single quotes",
+      "begin": "\\s?(~e''')$",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        },
+        "1": {
+          "name": "string.quoted.double.heredoc.elixir"
+        }
+      },
+      "end": "^\\s*('''[a-z]*)$",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        },
+        "1": {
+          "name": "string.quoted.double.heredoc.elixir"
+        }
+      },
+      "name": "text.html.elixir",
+      "patterns": [
+        {
+          "include": "text.html.elixir"
+        }
+      ]
+    },
+    {
+      "comment": "Embedded Liveview heredoc with double quotes",
+      "begin": "\\s?(~L\"\"\")$",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        },
+        "1": {
+          "name": "string.quoted.double.heredoc.elixir"
+        }
+      },
+      "end": "^\\s*(\"\"\"[a-z]*)$",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        },
+        "1": {
+          "name": "string.quoted.double.heredoc.elixir"
+        }
+      },
+      "name": "text.html.elixir",
+      "patterns": [
+        {
+          "include": "text.html.elixir"
+        }
+      ]
+    },
+    {
+      "comment": "Embededd Liveview heredoc with double quotes",
+      "begin": "\\s?(~l\"\"\")$",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        },
+        "1": {
+          "name": "string.quoted.double.heredoc.elixir"
+        }
+      },
+      "end": "^\\s*(\"\"\"[a-z]*)$",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        },
+        "1": {
+          "name": "string.quoted.double.heredoc.elixir"
+        }
+      },
+      "name": "text.html.elixir",
+      "patterns": [
+        {
+          "include": "text.html.elixir"
+        }
+      ]
+    },
+    {
+      "comment": "Embededd Liveview heredoc with single quotes",
+      "begin": "\\s?(~L''')$",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        },
+        "1": {
+          "name": "string.quoted.double.heredoc.elixir"
+        }
+      },
+      "end": "^\\s*('''[a-z]*)$",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        },
+        "1": {
+          "name": "string.quoted.double.heredoc.elixir"
+        }
+      },
+      "name": "text.html.elixir",
+      "patterns": [
+        {
+          "include": "text.html.elixir"
+        }
+      ]
+    },
+    {
+      "comment": "Embededd Liveview heredoc with single quotes",
+      "begin": "\\s?(~l''')$",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        },
+        "1": {
+          "name": "string.quoted.double.heredoc.elixir"
+        }
+      },
+      "end": "^\\s*('''[a-z]*)$",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        },
+        "1": {
+          "name": "string.quoted.double.heredoc.elixir"
+        }
+      },
+      "name": "text.html.elixir",
+      "patterns": [
+        {
+          "include": "text.html.elixir"
+        }
+      ]
+    },
+    {
       "begin": "~[a-z](?>\"\"\")",
       "beginCaptures": {
         "0": {


### PR DESCRIPTION
<details open="true">
<summary>hide</summary>

![image](https://user-images.githubusercontent.com/22575742/55028383-8b95f600-4fd5-11e9-94e3-b1ac3e0f0c18.png)


</details>

### Description

Got frustrated after scanning LiveView code without highlighting and started messing around in the config. Been using it for the past couple weeks and figured I'd make a PR like a responsible person.

- Adds `text.html.elixir` syntax rules within heredoc embedded elixir/liveview embeded elixir sigil matches after built-in sigil matches and before `~[a-z]` catch-all

Notes:
- Kept it scoped to multi-line and just quote separators to try and reduce potential interactions.
- My symbol's not being highlighted is due to a bad theme not a mismatch

<details>
<summary>show screenshot</summary>

![image](https://user-images.githubusercontent.com/22575742/55028969-fc89dd80-4fd6-11e9-963b-a4b0a1247532.png)


</details>

- Love the extension, thanks for all the great work ❤️ 