### PR TITLE
Use VSCode embedded language for html.eex files

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,13 @@
       {
         "language": "HTML (EEx)",
         "scopeName": "text.html.elixir",
-        "path": "./syntaxes/html (eex).json"
+        "path": "./syntaxes/html (eex).json",
+        "embeddedLanguages": {
+          "text.html": "html",
+          "source.elixir": "elixir",
+          "source.js": "javascript",
+          "source.css": "css"
+        }
       }
     ],
     "breakpoints": [


### PR DESCRIPTION
Allow VS Code to use different scopes for various languages used in embedded html files
Before:
![Before](https://imgur.com/download/g5mZTKQ)

After:
![After](https://imgur.com/download/rXqWEDs)

Same effect with `html`, `js` and `css` sections. 