### PR TITLE
Add `ElixirLS.trace.server` configuration UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,16 @@
           "type": "boolean",
           "description": "Suggest @spec annotations inline using Dialyzer's inferred success typings (Requires Dialyzer)",
           "default": true
+        },
+        "ElixirLS.trace.server": {
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "description": "Traces the communication between VS Code and the Elixir language server."
         }
       }
     },


### PR DESCRIPTION
Add `ElixirLS.trace.server` configuration UI, to control vscode-languageclient tracing.  Closes #137.