### PR TITLE
Add function call syntax scope

### DIFF
--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -185,6 +185,18 @@
       }
     },
     {
+      "comment": "Pipe operator call without parenthesis",
+      "match": "(\\|\\>)\\s*([a-z_]\\w*[!?]?)",
+      "captures": {
+        "1": {
+          "name": "keyword.operator.other.elixir"
+        },
+        "2": {
+          "name": "entity.name.function.elixir"
+        }
+      }
+    },
+    {
       "match": "\\b[a-z_]\\w*[!?]?(?=\\s*?\\.?\\s*?\\()",
       "name": "entity.name.function.elixir"
     },

--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -170,6 +170,25 @@
       }
     },
     {
+      "comment": "Erlang Function call without parenthesis",
+      "match": "(\\:\\w+)\\s*(\\.)\\s*([_]?\\w*[!?]?)",
+      "captures": {
+        "1": {
+          "name": "constant.other.symbol.elixir"
+        },
+        "2": {
+          "name": "punctuation.separator.method.elixir"
+        },
+        "3": {
+          "name": "entity.name.function.elixir"
+        }
+      }
+    },
+    {
+      "match": "\\b[a-z_]\\w*[!?]?(?=\\s*?\\.?\\s*?\\()",
+      "name": "entity.name.function.elixir"
+    },
+    {
       "match": "\\b[a-z_]\\w*[!?]?(?=\\s*?\\.?\\s*?\\()",
       "name": "entity.name.function.elixir"
     },

--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -201,10 +201,6 @@
       "name": "entity.name.function.elixir"
     },
     {
-      "match": "\\b[a-z_]\\w*[!?]?(?=\\s*?\\.?\\s*?\\()",
-      "name": "entity.name.function.elixir"
-    },
-    {
       "match": "\\b[A-Z]\\w*\\b",
       "name": "variable.other.constant.elixir"
     },

--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -156,15 +156,15 @@
     },
     {
       "comment": "Function call without parenthesis",
-      "match": "([A-Z]\\w+)(\\s*)(\\.)(\\s*)([a-z_]\\w*[!?]?)",
+      "match": "([A-Z]\\w+)\\s*(\\.)\\s*([a-z_]\\w*[!?]?)",
       "captures": {
         "1": {
           "name": "variable.other.constant.elixir"
         },
-        "3": {
+        "2": {
           "name": "punctuation.separator.method.elixir"
         },
-        "5": {
+        "3": {
           "name": "entity.name.function.elixir"
         }
       }

--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -155,6 +155,25 @@
       "name": "variable.language.elixir"
     },
     {
+      "comment": "Function call without parenthesis",
+      "match": "([A-Z]\\w+)(\\s*)(\\.)(\\s*)([a-z_]\\w*[!?]?)",
+      "captures": {
+        "1": {
+          "name": "variable.other.constant.elixir"
+        },
+        "3": {
+          "name": "punctuation.separator.method.elixir"
+        },
+        "5": {
+          "name": "entity.name.function.elixir"
+        }
+      }
+    },
+    {
+      "match": "\\b[a-z_]\\w*[!?]?(?=\\s*?\\.?\\s*?\\()",
+      "name": "entity.name.function.elixir"
+    },
+    {
       "match": "\\b[A-Z]\\w*\\b",
       "name": "variable.other.constant.elixir"
     },


### PR DESCRIPTION
Add the pattern to scope the function calls with parenthesis or dot/parenthesis and for `Module.function` i.e. any non ambiguous function call.
Allowing themes to change the color of them.

I've also [added to Sublime](https://github.com/elixir-editors/elixir-tmbundle/pull/179) and there you can find more of the reason behind it.
TL;DR We as community avoid ambiguous calls with the compilation warning and the formatter, so we should support this approach .

I've been using for some weeks now and has been a great experience.

<img width="546" alt="functions calls highlighted and 3 cases that it should not highlight" src="https://user-images.githubusercontent.com/17054180/64090776-5bd8e000-cd23-11e9-8197-ecfda8eb496b.png">
