### PR TITLE
Add missing comma in JSON

### DIFF
--- a/elixir-language-configuration.json
+++ b/elixir-language-configuration.json
@@ -20,7 +20,7 @@
 		{"open": "`", "close": "`", "notIn": ["string", "comment"]},
 		{"open": "(", "close": ")"},
 		{"open": "{", "close": "}"},
-		{"open": "[", "close": "]"}
+		{"open": "[", "close": "]"},
 		{"open": "<<", "close": ">>"}
 	],
 	"indentationRules": {


### PR DESCRIPTION
Missing comma in JSON file was causing parse errors logged to console in vscode