### PR TITLE
Add missing comma in language configuration file

### DIFF
--- a/elixir-language-configuration.json
+++ b/elixir-language-configuration.json
@@ -20,7 +20,7 @@
 		{"open": "`", "close": "`", "notIn": ["string", "comment"]},
 		{"open": "(", "close": ")"},
 		{"open": "{", "close": "}"},
-		{"open": "[", "close": "]"}
+		{"open": "[", "close": "]"},
 		{"open": "<<", "close": ">>"}
 	],
 	"indentationRules": {


### PR DESCRIPTION
While trying to make this extension work, my VSCode complained about a syntax error in the language configuration file.

It does not fix my issue, but I think it should be fixed anyway, so, here is a PR.